### PR TITLE
change clear button position & expand clickable area.

### DIFF
--- a/projects/ionic4-datepicker/src/lib/ionic4-datepicker.component.scss
+++ b/projects/ionic4-datepicker/src/lib/ionic4-datepicker.component.scss
@@ -27,5 +27,7 @@
     font-size: 18px;
     color: #a9a9a9;
     position: absolute;
+    padding: 8px;
+    margin: -8px;
   }
 }

--- a/projects/ionic4-datepicker/src/lib/ionic4-datepicker.component.scss
+++ b/projects/ionic4-datepicker/src/lib/ionic4-datepicker.component.scss
@@ -1,6 +1,7 @@
 :host {
   display: flex;
   align-items: center;
+  position: relative;
 
   input {
     font-size: 16px;


### PR DESCRIPTION
## JIRA issue URL
<!-- ブランチ名・PRタイトル・コミットメッセージにJIRA issueのkey(ATAMA-000)を含めるとJIRAからは自動でリンクされます -->
https://atamaplus.atlassian.net/browse/APPTEAM-3708

## Specification
<!-- Description of modified specification -->

- iPhone SE等でdatepickerの表示位置が折り返された際に、クリアボタンが枠からはみ出る問題を修正しました。
- クリアボタンをうまく押せない問題を修正しました。

(ラベルの修正は [change date select label &amp; update ionic4-datepicker by rettar5 · Pull Request #3920 · atamaplus/atamaplus-mobile](https://github.com/atamaplus/atamaplus-mobile/pull/3920) で実施します。 )

<img width="820" alt="スクリーンショット 2020-10-22 14 48 06" src="https://user-images.githubusercontent.com/12378661/96830009-a06a9200-1475-11eb-93ed-4e2855aceb82.png">


## UI changes
<!-- Put screenshots when UI changes -->

<details>
<summary>Web</summary>
  
緑(padding)の部分が今回クリック判定として追加された範囲。

<img width="368" alt="スクリーンショット 2020-10-22 14 41 29" src="https://user-images.githubusercontent.com/12378661/96830064-bc6e3380-1475-11eb-8af2-8598dd82db08.png">

</details>

<!-- 
<details>
<summary>iOS</summary>
  
</details>
<details>
<summary>Android</summary>

</details>
-->


## Test cases


## Note
<!-- review points or how to reproduce -->



